### PR TITLE
fix unicode file name missing

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,3 @@
+# https://github.com/carrierwaveuploader/carrierwave#filenames-and-unicode-chars
+
+CarrierWave::SanitizedFile.sanitize_regexp = /[^[:word:]\.\-\+]/


### PR DESCRIPTION
修复上传的文件中文名被替换为下划线的问题
